### PR TITLE
Ease use of non-default controller port

### DIFF
--- a/controller_client.coffee
+++ b/controller_client.coffee
@@ -9,7 +9,7 @@ module.exports = class ControllerClient
 
         @config =
             host: @options.host || 'localhost'
-            port: @options.port || 9002
+            port: @options.port || process.env.CONTROLLER_PORT || 9002
 
         @client = new Client "http://#{@config.host}:#{@config.port}/"
         @client.setToken @options.token if @options.token?


### PR DESCRIPTION
Set default controller port to be the one provided by CONTROLLER_PORT env variable

Fixes https://github.com/cozy/cozy-home/issues/805.

Note: I am not very familiar with coffeescript and the way I should make a PR on this repo. Please let me know if I should include additional stuffs, such as a rebuild of JavaScript files. Thanks!
